### PR TITLE
Fix a race condition in KpixRun and KpixCalibration

### DIFF
--- a/firmware/common/python/KpixDaq/_DesyTracker.py
+++ b/firmware/common/python/KpixDaq/_DesyTracker.py
@@ -30,15 +30,15 @@ class DesyTracker(pyrogue.Device):
 
         @self.command()
         def EthAcquire():
-            f = self.root.cmd._reqFrame(1, False)
+            f = cmd._reqFrame(1, False)
             f.write(self.__acquireCmd, 0)
-            self.root.cmd._sendFrame(f)
+            cmd._sendFrame(f)
 
         @self.command()
         def EthStart():
-            f = self.root.cmd._reqFrame(1, False)
+            f = cmd._reqFrame(1, False)
             f.write(self.__startCmd, 0)
-            self.root.cmd._sendFrame(f)
+            cmd._sendFrame(f)
 
 
         self.add(surf.axi.AxiVersion(

--- a/firmware/common/python/KpixDaq/_DesyTracker.py
+++ b/firmware/common/python/KpixDaq/_DesyTracker.py
@@ -18,9 +18,6 @@ class FrameInfo(rogue.interfaces.stream.Slave):
         print(f' Got frame with {frame.getPayload()} bytes')
 
 
-
-
-
 class DesyTracker(pyrogue.Device):
     def __init__(self, cmd, ethDebug, sim, **kwargs):
         super().__init__(**kwargs)

--- a/firmware/common/python/KpixDaq/_DesyTrackerRoot.py
+++ b/firmware/common/python/KpixDaq/_DesyTrackerRoot.py
@@ -24,61 +24,60 @@ class DesyTrackerRoot(pyrogue.Root):
         self.sim = sim
 
         if hwEmu:
-            self.srp = pyrogue.interfaces.simulation.MemEmulate()
-            self.dataStream = rogue.interfaces.stream.Master()
-            self.cmd = rogue.interfaces.stream.Master()
+            srp = pyrogue.interfaces.simulation.MemEmulate()
+            dataStream = rogue.interfaces.stream.Master()
+            cmd = rogue.interfaces.stream.Master()
+
+            self.manage(srp, dataStream, cmd)
 
         else:
             if sim:
-                self.dest0 = rogue.interfaces.stream.TcpClient('localhost', 9000)
-                self.dest1 = rogue.interfaces.stream.TcpClient('localhost', 9002)
+                dest0 = rogue.interfaces.stream.TcpClient('localhost', 9000)
+                dest1 = rogue.interfaces.stream.TcpClient('localhost', 9002)
+
+                self.manage(dest0, dest1)
 
             else:
-                self.udp = pyrogue.protocols.UdpRssiPack( host=ip, port=8192, packVer=2 )
-                self.dest0 = self.udp.application(dest=0)
-                self.dest1 = self.udp.application(dest=1)
+                udp = pyrogue.protocols.UdpRssiPack( host=ip, port=8192, packVer=2 )
+                dest0 = udp.application(dest=0)
+                dest1 = udp.application(dest=1)
                 if ethDebug:
-                    self.dest2 = self.udp.application(dest=2)
-                    self.dest3 = self.udp.application(dest=3)
+                    dest2 = udp.application(dest=2)
+                    dest3 = udp.application(dest=3)
 
-            self.srp = rogue.protocols.srp.SrpV3()
-            self.cmd = rogue.interfaces.stream.Master()
+                self.manage(udp, dest0, dest1, dest2, dest3)
+
+            srp = rogue.protocols.srp.SrpV3()
+            cmd = rogue.interfaces.stream.Master()
+
+            self.manage(srp, cmd)
 
             dataWriter = pyrogue.utilities.fileio.LegacyStreamWriter(name='DataWriter')
 
-            self.srp == self.dest0
-            self.dest1 >> dataWriter.getDataChannel()
-            self.dest1 << self.cmd
+            srp == dest0
+            dest1 >> dataWriter.getDataChannel()
+            dest1 << cmd
 
             # Connect update stream
             self >> dataWriter.getYamlChannel()
 
             if dataDebug:
                 fp = KpixDaq.KpixStreamInfo()
-                self.dest1 >> fp
+                dest1 >> fp
 
             self.add(dataWriter)
             self.add(KpixDaq.DesyTrackerRunControl())
 
-        self.add(KpixDaq.DesyTracker(memBase=self.srp, cmd=self.cmd, offset=0, ethDebug=ethDebug, sim=sim, enabled=True, expand=True))
+        self.add(KpixDaq.DesyTracker(memBase=srp, cmd=cmd, offset=0, ethDebug=ethDebug, sim=sim, enabled=True, expand=True))
 
         if ethDebug:
-            self.add(self.udp)
-            self.add(pyrogue.utilities.prbs.PrbsTx(stream=self.dest2))
-            self.add(pyrogue.utilities.prbs.PrbsRx(stream=self.dest2))
+            self.add(udp)
+            self.add(pyrogue.utilities.prbs.PrbsTx(stream=dest2))
+            self.add(pyrogue.utilities.prbs.PrbsRx(stream=dest2))
 
-            self.add(pyrogue.utilities.prbs.PrbsTx(name='PrbsTxLoopback', stream=self.dest3))
-            self.add(pyrogue.utilities.prbs.PrbsRx(name='PrbsRxLoopback', stream=self.dest3))
+            self.add(pyrogue.utilities.prbs.PrbsTx(name='PrbsTxLoopback', stream=dest3))
+            self.add(pyrogue.utilities.prbs.PrbsRx(name='PrbsRxLoopback', stream=dest3))
 
-
-    def stop(self):
-        if hasattr(self, 'udp'):
-            self.udp._rssi._stop()
-        elif hasattr(self, 'dest0'):
-            # sim mode
-            self.dest0.close()
-            self.dest1.close()
-        super().stop()
 
 class DesyTrackerRootArgparser(argparse.ArgumentParser):
     def __init__(self):

--- a/firmware/common/python/KpixDaq/_DesyTrackerRoot.py
+++ b/firmware/common/python/KpixDaq/_DesyTrackerRoot.py
@@ -28,14 +28,17 @@ class DesyTrackerRoot(pyrogue.Root):
             dataStream = rogue.interfaces.stream.Master()
             cmd = rogue.interfaces.stream.Master()
 
-            self.manage(srp, dataStream, cmd)
+            self.addInterface(srp)
+            self.addInterface(dataStream)
+            self.addInterface(cmd)
 
         else:
             if sim:
                 dest0 = rogue.interfaces.stream.TcpClient('localhost', 9000)
                 dest1 = rogue.interfaces.stream.TcpClient('localhost', 9002)
 
-                self.manage(dest0, dest1)
+                self.addInterface(dest0)
+                self.addInterface(dest1)
 
             else:
                 udp = pyrogue.protocols.UdpRssiPack( host=ip, port=8192, packVer=2 )
@@ -45,12 +48,13 @@ class DesyTrackerRoot(pyrogue.Root):
                     dest2 = udp.application(dest=2)
                     dest3 = udp.application(dest=3)
 
-                self.manage(udp, dest0, dest1, dest2, dest3)
+                self.addInterface(udp)
 
             srp = rogue.protocols.srp.SrpV3()
             cmd = rogue.interfaces.stream.Master()
 
-            self.manage(srp, cmd)
+            self.addInterface(srp)
+            self.addInterface(cmd)
 
             dataWriter = pyrogue.utilities.fileio.LegacyStreamWriter(name='DataWriter')
 

--- a/firmware/common/python/KpixDaq/_KpixAsic.py
+++ b/firmware/common/python/KpixDaq/_KpixAsic.py
@@ -6,7 +6,6 @@ class KpixLocal(pr.Device):
 
         self.forceCheckEach = True
 
-
         self.STATUS = 0x0000*4
         self.CONFIG = 0x0001*4
         self.TIMER_A = 0x0008*4

--- a/firmware/common/python/KpixDaq/_SysConfig.py
+++ b/firmware/common/python/KpixDaq/_SysConfig.py
@@ -6,8 +6,7 @@ class SysConfig(pr.Device):
     def KpixEnableUpdate(self, path, varValue):
         index = int(re.search('.*?KpixAsic\\[(.*?)\\]', path).groups()[0])
         if self.KpixEnable[index].value() != varValue.value:
-            with self._root.updateGroup():
-                self.KpixEnable[index].set(varValue.value, write=True)
+            self.KpixEnable[index].set(varValue.value, write=True)
 
 
     def __init__(self, numKpix, **kwargs):

--- a/firmware/common/python/KpixDaq/_SysConfig.py
+++ b/firmware/common/python/KpixDaq/_SysConfig.py
@@ -6,10 +6,14 @@ class SysConfig(pr.Device):
     def KpixEnableUpdate(self, path, varValue):
         index = int(re.search('.*?KpixAsic\\[(.*?)\\]', path).groups()[0])
         if self.KpixEnable[index].value() != varValue.value:
-            self.KpixEnable[index].set(varValue.value, write=True)
+            with self._root.updateGroup():
+                self.KpixEnable[index].set(varValue.value, write=True)
+
 
     def __init__(self, numKpix, **kwargs):
         super().__init__(**kwargs)
+
+#        self.forceCheckEach = True
 
         self.add(pr.RemoteVariable(
             name = 'RawDataMode',

--- a/software/scripts/KpixCalibration
+++ b/software/scripts/KpixCalibration
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     rootArgs = rootParser.parse_known_args()[0]
     runArgs = runParser.parse_known_args()[0]
-    
+
     with KpixDaq.DesyTrackerRoot(**vars(rootArgs)) as root:
 
         root.ReadAll()
@@ -48,19 +48,20 @@ if __name__ == "__main__":
 
         if os.path.isdir(runArgs.outfile):
             runArgs.outfile = os.path.abspath(datetime.datetime.now().strftime(f"{runArgs.outfile}/Calibration_%Y%m%d_%H%M%S.dat"))
-            
+
         print(f'Opening data file: {runArgs.outfile}')
         root.DataWriter.DataFile.setDisp(runArgs.outfile)
         root.DataWriter.Open()
 
         print(f"Hard Reset")
         root.HardReset()
-        
-        print(f"Count Reset")        
+
+        print(f"Count Reset")
         root.CountReset()
-            
+
         print('Writing initial configuration')
         root.LoadConfig(runArgs.config)
+        root.waitOnUpdate()
         root.ReadAll()
         root.waitOnUpdate()
 
@@ -70,6 +71,4 @@ if __name__ == "__main__":
             root.DataWriter.Close()
         except (KeyboardInterrupt):
             root.DesyTrackerRunControl.runState.setDisp('Stopped')
-            root.DataWriter.Close()            
-            
-        
+            root.DataWriter.Close()

--- a/software/scripts/KpixRun
+++ b/software/scripts/KpixRun
@@ -78,6 +78,8 @@ if __name__ == "__main__":
             
         print('Writing initial configuration')
         root.LoadConfig(runArgs.config)
+        root.waitOnUpdate()
+        
         root.ReadAll()
         root.waitOnUpdate()
 


### PR DESCRIPTION
The run and calibration scripts were calling `root.ReadAll()` before `root.LoadConfig()` was done. This caused a strange race condition where sometimes `SysConfig.KpixEnable[x]` would not be properly set.